### PR TITLE
#1 - Fixed issue with django admin startapp command where trailing slash in directory name results in error

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -74,7 +74,7 @@ class TemplateCommand(BaseCommand):
                 raise CommandError(e)
         else:
             if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
+                self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2206,6 +2206,13 @@ class StartApp(AdminScriptTestCase):
             "another directory."
         )
 
+    def test_trailing_slash_in_target_app_directory_name(self):
+        app_dir = os.path.join(self.test_dir, 'apps', 'app1')
+        os.makedirs(app_dir)
+        _, err = self.run_django_admin(['startapp', 'app', os.path.join('apps', 'app1', '')])
+        self.assertNoOutput(err)
+        self.assertIs(os.path.exists(os.path.join(app_dir, 'apps.py')), True)
+
     def test_overlaying_app(self):
         # Use a subdirectory so it is outside the PYTHONPATH.
         os.makedirs(os.path.join(self.test_dir, 'apps/app1'))


### PR DESCRIPTION
Resolves #1
### Introduction
The purpose of this pull request is to address the issue where the `django-admin startapp` command fails when the provided directory name has a trailing slash. This issue arises from the fact that `os.path.basename()` returns an empty string when given a path with a trailing slash, which is not a valid directory name.

### Changes Made
To solve this problem, the `self.validate_name(os.path.basename(target), 'directory')` line in the `templates.py` file has been modified to `self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')`. This change removes any trailing slashes from the directory name before passing it to `os.path.basename()`, ensuring that the command works correctly even when the directory name has a trailing slash.

### Benefits
The benefits of this change include:
*   The `django-admin startapp` command now works correctly even when the directory name has a trailing slash.
*   This change does not introduce any backwards compatibility issues, as it only affects the handling of directory names with trailing slashes.
*   The code remains consistent with the existing logic for handling directory names, making it easier to understand and maintain.

### Tests and Example Uses
To test this change, you can use the `django-admin startapp` command with a directory name that has a trailing slash. For example:
```bash
django-admin startapp myapp /
```
Before this change, this command would fail with an error message indicating that the directory name is not valid. After this change, the command should succeed and create the new application in the specified directory.