### PR TITLE
#1 - Fix django admin startapp command to handle directory names with trailing slashes

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -74,7 +74,7 @@ class TemplateCommand(BaseCommand):
                 raise CommandError(e)
         else:
             if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
+                self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "


### PR DESCRIPTION
Resolves #1
### Problem Statement
The `django-admin startapp` command fails when a trailing slash is present in the directory name. This is due to the `os.path.basename` function not removing trailing slashes, causing the `validate_name` method to fail.

### Solution
To fix this issue, I edited the `management/templates.py` file to modify the line `self.validate_name(os.path.basename(target), 'directory')` to `self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')`. This change removes any trailing slashes from the directory path before validating it.

### Changes Made
* Viewed the contents of `management/templates.py` to understand the issue
* Edited `management/templates.py` to remove trailing slashes from directory paths before validation

### Testing
The changes should be tested by running the `django-admin startapp` command with a directory name that has a trailing slash. The command should now succeed and create the app directory without any errors.