### PR TITLE
#1 - Fixed django admin startapp with trailing slash in directory name by removing trailing slashes from target path

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -74,7 +74,7 @@ class TemplateCommand(BaseCommand):
                 raise CommandError(e)
         else:
             if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
+                self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "


### PR DESCRIPTION
Resolves #1
### Changes Made
The changes made in this pull request address the issue of `django-admin startapp` command failing when the directory name has a trailing slash. 

### Step-by-Step Solution
1. **List and View Files**: First, I listed all the files in the repository and viewed the contents of the `django/core/management/templates.py` file to understand the problem.
2. **Identify the Issue**: The issue was found in the `validate_name` function where it calls `os.path.basename` on the target path without considering any trailing slashes.
3. **Modify the Code**: I modified the line `self.validate_name(os.path.basename(target), 'directory')` to `self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')` to remove any trailing slashes from the target path.

### Explanation of Changes
* The `rstrip` method is used to remove trailing slashes from the target path.
* This change ensures that the `validate_name` function works correctly even when the directory name has a trailing slash.

### Tests and Example Uses
* To test the changes, you can run the `django-admin startapp` command with a directory name that has a trailing slash.
* For example: `django-admin startapp myapp/` should now work correctly without raising any errors.