### PR TITLE
#1 - Fix for django admin startapp command to handle directory names with trailing slashes

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -74,7 +74,7 @@ class TemplateCommand(BaseCommand):
                 raise CommandError(e)
         else:
             if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
+                self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "


### PR DESCRIPTION
Resolves #1
### Summary of Changes
This PR addresses the issue of `django-admin startapp` command failing when the directory name has a trailing slash. The error occurs because the `basename()` function is called on the path without considering the trailing slash.

### Step-by-Step Analysis of the Problem
1. **Identified the source of the issue**: The problem lies in the `templates.py` file within the `django/core/management` directory.
2. **Located the specific line causing the error**: The line `self.validate_name(os.path.basename(target), 'directory')` is where the error occurs.
3. **Understood the reason for the error**: The `basename()` function does not account for the trailing slash in the directory name, resulting in an empty string being passed to `validate_name()`, which expects a valid directory name.

### Explanation of Changes
* **Modified the line causing the error**: Changed `self.validate_name(os.path.basename(target), 'directory')` to `self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')` to remove the trailing slash from the directory name before calling `basename()`.

### Tests and Example Uses
* **Test the `django-admin startapp` command**: After applying this change, the command should successfully create a new Django app even when the directory name has a trailing slash.
* **Verify the `validate_name()` function**: Ensure that the function correctly handles directory names with and without trailing slashes.

### Checklist
- [x] Modified the `templates.py` file to fix the issue
- [x] Tested the `django-admin startapp` command with directory names having trailing slashes
- [x] Verified the correctness of the `validate_name()` function