### PR TITLE
#1 - Fixed django admin startapp command to handle trailing slashes in directory names

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -74,7 +74,7 @@ class TemplateCommand(BaseCommand):
                 raise CommandError(e)
         else:
             if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
+                self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "


### PR DESCRIPTION
Resolves #1
### Problem Statement
The `django-admin startapp` command was failing when the directory name had a trailing slash. This was due to the `validate_name` function in `django/core/management/templates.py` not handling trailing slashes correctly.

### Solution
To fix this issue, I modified the `handle` function in `django/core/management/templates.py` to remove any trailing slashes from the `target` path before calling `os.path.basename`. This ensures that the `validate_name` function is called with the correct path.

### Changes Made
* Modified the `handle` function in `django/core/management/templates.py` to remove trailing slashes from the `target` path
* Updated the `validate_name` function call to use `target.rstrip(os.sep)` instead of `target`

### Testing
The changes were tested by running the `django-admin startapp` command with a directory name that had a trailing slash. The command now successfully creates the app without throwing an error.

### Conclusion
With these changes, the `django-admin startapp` command now correctly handles directory names with trailing slashes, preventing errors and making it easier to create new Django apps.