### PR TITLE
#1 - Fix bug where trailing slash in directory name causes django admin startapp to fail by removing trailing slash from target path in validate_name method

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -74,7 +74,7 @@ class TemplateCommand(BaseCommand):
                 raise CommandError(e)
         else:
             if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
+                self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "


### PR DESCRIPTION
Resolves #1
### Summary of Changes
The changes made in this pull request address the issue where `django-admin startapp` with a trailing slash in the directory name results in an error. The error occurs because the `validate_name` method in the `TemplateCommand` class does not consider trailing slashes when checking the validity of the directory name.

### Step-by-Step Explanation
1. **Viewed the `django/core/management/templates.py` file**: To understand the cause of the issue, the contents of the `templates.py` file were viewed. This file contains the `TemplateCommand` class, which is responsible for handling the creation of new Django applications and projects.
2. **Identified the issue**: The `validate_name` method in the `TemplateCommand` class was identified as the cause of the issue. This method checks if the provided directory name is valid, but it does not account for trailing slashes.
3. **Edited the `django/core/management/templates.py` file**: The `validate_name` method was updated to remove any trailing slashes from the directory name using the `rstrip` method. This ensures that the method correctly handles directory names with trailing slashes.

### Code Changes
The following code change was made:
```python
self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
```
This change removes any trailing slashes from the `target` path before passing it to the `validate_name` method, ensuring that the method correctly validates the directory name.

### Conclusion
With these changes, the `django-admin startapp` command should now correctly handle directory names with trailing slashes, preventing the error that previously occurred.