### PR TITLE
#1 - Fixed django admin startapp command to handle trailing slashes in directory names

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -74,7 +74,7 @@ class TemplateCommand(BaseCommand):
                 raise CommandError(e)
         else:
             if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
+                self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "


### PR DESCRIPTION
Resolves #1
### Problem Statement
The `django-admin startapp` command was appending a trailing slash to the directory name, resulting in an error. This issue was caused by the `validate_name` method in `django/core/management/templates.py` not accounting for trailing slashes when validating the directory name.

### Changes Made
To fix this issue, I modified the `validate_name` method in `django/core/management/templates.py` to remove any trailing slashes from the directory name before validation. This was achieved by changing the line `self.validate_name(os.path.basename(target), 'directory')` to `self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')`.

### Explanation of Changes
* The `os.path.basename` function is used to get the base name of the directory path.
* The `rstrip` method is used to remove any trailing slashes from the directory name.
* The `os.sep` constant is used to specify the separator to be removed, which is the appropriate separator for the operating system being used.

### Testing
The changes were tested by running the `django-admin startapp` command with a directory name that had a trailing slash. The command now successfully creates the app without throwing an error.

### Conclusion
The changes made fix the issue with the `django-admin startapp` command appending a trailing slash to the directory name, ensuring that the command works as expected in all scenarios.