### PR TITLE
#15 - Fixed issue with trailing slash in directory name when using django admin startapp by modifying the validate name function in templates py to remove trailing slashes from target path

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -74,7 +74,7 @@ class TemplateCommand(BaseCommand):
                 raise CommandError(e)
         else:
             if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
+                self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "


### PR DESCRIPTION
Resolves #15
### Introduction
This PR fixes an issue where `django-admin startapp` with a trailing slash in the directory name results in an error. The error occurs because the `basename` function is called on the `target` path without considering a trailing slash.

### Changes Made
To solve this issue, I have made the following changes:

* Listed the files in the `django` directory and its subdirectories to understand the structure of the codebase.
* Viewed the contents of the `templates.py` file to identify the line of code causing the error.
* Updated the `templates.py` file to remove the trailing slash from the `target` path before calling the `basename` function. This was achieved by replacing the line `self.validate_name(os.path.basename(target), 'directory')` with `self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')`.

### Explanation of Changes
The `rstrip(os.sep)` function removes the trailing slash from the `target` path, ensuring that the `basename` function returns the correct directory name. This fix prevents the `CommandError` that occurs when the `basename` function is called on a path with a trailing slash.

### Conclusion
With these changes, the `django-admin startapp` command should now work correctly even when the directory name has a trailing slash. This PR fixes the issue and improves the overall user experience.